### PR TITLE
Imgur API v3 gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
         /* Lets build a FormData object*/
         var fd = new FormData(); // I wrote about it: https://hacks.mozilla.org/2011/01/how-to-develop-a-html5-image-uploader/
         fd.append("image", file); // Append the file
-        fd.append("key", "6528448c258cff474ca9701c5bab6927"); // Get your own key http://api.imgur.com/
+        xhr.setRequestHeader('Authorization', 'Client-ID <your_client-id_here>'); // Get your own key http://api.imgur.com/
         var xhr = new XMLHttpRequest(); // Create the XHR (Cross-Domain XHR FTW!!!) Thank you sooooo much imgur.com
-        xhr.open("POST", "http://api.imgur.com/2/upload.json"); // Boooom!
+        xhr.open("POST", "http://api.imgur.com/3/image.json"); // Boooom!
         xhr.onload = function() {
             // Big win!
-            document.querySelector("#link").href = JSON.parse(xhr.responseText).upload.links.imgur_page;
+            document.querySelector("#link").href = JSON.parse(xhr.responseText).data.link;
             document.body.className = "uploaded";
         }
         // Ok, I don't handle the errors. An exercice for the reader.

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
         
         xhr.setRequestHeader('Authorization', 'Client-ID 28aaa2e823b03b1'); // Get your own key http://api.imgur.com/
         
-        // Ok, I don't handle the errors. An exercice for the reader.
+        // Ok, I don't handle the errors. An exercise for the reader.
 
         /* And now, we send the formdata */
         xhr.send(fd);

--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
         /* Lets build a FormData object*/
         var fd = new FormData(); // I wrote about it: https://hacks.mozilla.org/2011/01/how-to-develop-a-html5-image-uploader/
         fd.append("image", file); // Append the file
-        xhr.setRequestHeader('Authorization', 'Client-ID 28aaa2e823b03b1'); // Get your own key http://api.imgur.com/
         var xhr = new XMLHttpRequest(); // Create the XHR (Cross-Domain XHR FTW!!!) Thank you sooooo much imgur.com
         xhr.open("POST", "http://api.imgur.com/3/image.json"); // Boooom!
         xhr.onload = function() {
@@ -65,6 +64,9 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
             document.querySelector("#link").href = JSON.parse(xhr.responseText).data.link;
             document.body.className = "uploaded";
         }
+        
+        xhr.setRequestHeader('Authorization', 'Client-ID 28aaa2e823b03b1'); // Get your own key http://api.imgur.com/
+        
         // Ok, I don't handle the errors. An exercice for the reader.
 
         /* And now, we send the formdata */

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
         /* Lets build a FormData object*/
         var fd = new FormData(); // I wrote about it: https://hacks.mozilla.org/2011/01/how-to-develop-a-html5-image-uploader/
         fd.append("image", file); // Append the file
-        xhr.setRequestHeader('Authorization', 'Client-ID <your_client-id_here>'); // Get your own key http://api.imgur.com/
+        xhr.setRequestHeader('Authorization', 'Client-ID 28aaa2e823b03b1'); // Get your own key http://api.imgur.com/
         var xhr = new XMLHttpRequest(); // Create the XHR (Cross-Domain XHR FTW!!!) Thank you sooooo much imgur.com
         xhr.open("POST", "http://api.imgur.com/3/image.json"); // Boooom!
         xhr.onload = function() {

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ have icons. Yes. Think about Fvwm (Linux) users like me -->
         var fd = new FormData(); // I wrote about it: https://hacks.mozilla.org/2011/01/how-to-develop-a-html5-image-uploader/
         fd.append("image", file); // Append the file
         var xhr = new XMLHttpRequest(); // Create the XHR (Cross-Domain XHR FTW!!!) Thank you sooooo much imgur.com
-        xhr.open("POST", "http://api.imgur.com/3/image.json"); // Boooom!
+        xhr.open("POST", "https://api.imgur.com/3/image.json"); // Boooom!
         xhr.onload = function() {
             // Big win!
             document.querySelector("#link").href = JSON.parse(xhr.responseText).data.link;


### PR DESCRIPTION
Updated gh-pages example to utilize a Client-ID instead of a key, which is now required for imgur v3 API.
